### PR TITLE
Fix the typing of getOverrides()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -89,7 +89,7 @@ declare namespace statsig {
    * @returns {Record<string, any>} - an object with key-value pairs each representing the override's name and return value
    * @throws Error if initialize() is not called first
    */
-  function getOverrides(): Promise<Record<string, any>>;
+  function getOverrides(): Record<string, any>;
 
   /**
    * DO NOT CALL DIRECTLY.


### PR DESCRIPTION
The function returns an object but the type definition says it's a promise.