### PR TITLE
Disaster config

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "debugbuild": "tsc && webpack --mode development",
     "prepublish": "tsc && webpack",
     "postbuild": "rm -rf build/**/*.map",
     "test": "jest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,23 +39,17 @@ export default class Statsig {
   }
 
   public static checkGate(gateName: string): boolean {
-    if (!Statsig.instance) {
-      throw new Error('Call and wait for initialize() to finish first.');
-    }
+    this.ensureInitialized();
     return Statsig.instance.checkGate(gateName);
   }
 
   public static getConfig(configName: string): DynamicConfig {
-    if (!Statsig.instance) {
-      throw new Error('Call and wait for initialize() to finish first.');
-    }
+    this.ensureInitialized();
     return Statsig.instance.getConfig(configName);
   }
 
   public static async getFailsafeConfig(): Promise<DynamicConfig> {
-    if (!Statsig.instance) {
-      throw new Error('Call and wait for initialize() to finish first.');
-    }
+    this.ensureInitialized();
     return await Statsig.instance.getFailsafeConfig();
   }
 
@@ -63,9 +57,7 @@ export default class Statsig {
     experimentName: string,
     keepDeviceValue: boolean = false,
   ): DynamicConfig {
-    if (!Statsig.instance) {
-      throw new Error('Call and wait for initialize() to finish first.');
-    }
+    this.ensureInitialized();
     return Statsig.instance.getExperiment(experimentName, keepDeviceValue);
   }
 
@@ -74,23 +66,17 @@ export default class Statsig {
     value: string | number | null = null,
     metadata: Record<string, string> | null = null,
   ): void {
-    if (!Statsig.instance) {
-      throw new Error('Call and wait for initialize() to finish first.');
-    }
+    this.ensureInitialized();
     Statsig.instance.logEvent(eventName, value, metadata);
   }
 
   public static updateUser(user: StatsigUser | null): Promise<boolean> {
-    if (!Statsig.instance) {
-      throw new Error('Call and wait for initialize() to finish first.');
-    }
+    this.ensureInitialized();
     return Statsig.instance.updateUser(user);
   }
 
   public static shutdown() {
-    if (!Statsig.instance) {
-      throw new Error('Call and wait for initialize() to finish first.');
-    }
+    this.ensureInitialized();
     Statsig.instance.shutdown();
   }
 
@@ -100,9 +86,7 @@ export default class Statsig {
    * @param value - value to assign to the gate
    */
   public static overrideGate(gateName: string, value: boolean): void {
-    if (!Statsig.instance) {
-      throw new Error('Call and wait for initialize() to finish first.');
-    }
+    this.ensureInitialized();
     Statsig.instance.overrideGate(gateName, value);
   }
 
@@ -112,9 +96,7 @@ export default class Statsig {
    * @param value - value to assign to the config
    */
   public static overrideConfig(configName: string, value: object): void {
-    if (!Statsig.instance) {
-      throw new Error('Call and wait for initialize() to finish first.');
-    }
+    this.ensureInitialized();
     Statsig.instance.overrideConfig(configName, value);
   }
 
@@ -123,9 +105,7 @@ export default class Statsig {
    * @param name the gate override to remove
    */
   public static removeOverride(name?: string): void {
-    if (!Statsig.instance) {
-      throw new Error('Call and wait for initialize() to finish first.');
-    }
+    this.ensureInitialized();
     Statsig.instance.removeOverride(name);
   }
 
@@ -133,9 +113,7 @@ export default class Statsig {
    * @param name the gate override to remove
    */
   public static removeGateOverride(name?: string): void {
-    if (!Statsig.instance) {
-      throw new Error('Call and wait for initialize() to finish first.');
-    }
+    this.ensureInitialized();
     Statsig.instance.removeGateOverride(name);
   }
 
@@ -143,9 +121,7 @@ export default class Statsig {
    * @param name the config override to remove
    */
   public static removeConfigOverride(name?: string): void {
-    if (!Statsig.instance) {
-      throw new Error('Call and wait for initialize() to finish first.');
-    }
+    this.ensureInitialized();
     Statsig.instance.removeConfigOverride(name);
   }
 
@@ -154,9 +130,7 @@ export default class Statsig {
    * @returns the gate overrides
    */
   public static getOverrides(): Record<string, any> {
-    if (!Statsig.instance) {
-      throw new Error('Call and wait for initialize() to finish first.');
-    }
+    this.ensureInitialized();
     return Statsig.instance.getOverrides();
   }
 
@@ -164,9 +138,13 @@ export default class Statsig {
    * @returns The local gate and config overrides
    */
   public static getAllOverrides(): StatsigOverrides {
+    this.ensureInitialized();
+    return Statsig.instance.getAllOverrides();
+  }
+
+  private static ensureInitialized() {
     if (!Statsig.instance) {
       throw new Error('Call and wait for initialize() to finish first.');
     }
-    return Statsig.instance.getAllOverrides();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,13 @@ export default class Statsig {
     return Statsig.instance.getConfig(configName);
   }
 
+  public static async getFailsafeConfig(): Promise<DynamicConfig> {
+    if (!Statsig.instance) {
+      throw new Error('Call and wait for initialize() to finish first.');
+    }
+    return await Statsig.instance.getFailsafeConfig();
+  }
+
   public static getExperiment(
     experimentName: string,
     keepDeviceValue: boolean = false,


### PR DESCRIPTION
A static config that's stored in a separate CDN than all the rest of our services.  
This config is not user-targetable, and only one instance exists for every API key.
The config can be updated via a script - we could eventually make this editable via our console (but usually this will be used when our services are inaccessible, so that might be noop)
Currently it's stored in CloudFlare via web workers.
Update happens via:
```curl https://api.statsig1.com/failsafe/put/[CLIENT API KEY] -X POST -d '{"msg":"Hello World"}'```