### PR TITLE
Accept optional type guard in DynamicConfig getter

### DIFF
--- a/src/DynamicConfig.ts
+++ b/src/DynamicConfig.ts
@@ -16,8 +16,15 @@ export default class DynamicConfig {
     this.secondaryExposures = secondaryExposures;
   }
 
-  public get<T>(key: string, defaultValue: T): T {
+  public get<T>(
+    key: string,
+    defaultValue: T,
+    typeGuard?: (value: unknown) => value is T,
+  ): T {
     const val = this.getValue(key, defaultValue);
+    if (typeGuard) {
+      return typeGuard(val) ? val : defaultValue;
+    }
     if (defaultValue != null) {
       if (Array.isArray(defaultValue)) {
         if (Array.isArray(val)) {

--- a/src/__tests__/DynamicConfigTyped.test.ts
+++ b/src/__tests__/DynamicConfigTyped.test.ts
@@ -20,6 +20,26 @@ describe('Verify behavior of DynamicConfig', () => {
     'default',
   );
 
+  type TestObject = {
+    key: string;
+    key2: number;
+  };
+
+  type OtherTestObject = {
+    someProp: string;
+    otherProp: number;
+  };
+
+  const isTestObject = (obj: any): obj is TestObject => {
+    return typeof obj?.key === 'string' && typeof obj?.key2 === 'number';
+  };
+
+  const isOtherTestObject = (obj: any): obj is OtherTestObject => {
+    return (
+      typeof obj?.someProp === 'string' && typeof obj?.otherProp === 'number'
+    );
+  };
+
   beforeEach(() => {
     expect.hasAssertions();
   });
@@ -36,5 +56,57 @@ describe('Verify behavior of DynamicConfig', () => {
       key: 'value',
       key2: 123,
     });
+  });
+
+  test('Test optional type guard when runtime check succeeds', () => {
+    const defaultTestObject: TestObject = {
+      key: 'default',
+      key2: 0,
+    };
+    expect(
+      testConfig.get('object', defaultTestObject, isTestObject),
+    ).toStrictEqual({
+      key: 'value',
+      key2: 123,
+    });
+  });
+
+  test('Test optional type guard default', () => {
+    const defaultOtherTestObject: OtherTestObject = {
+      someProp: 'other',
+      otherProp: 0,
+    };
+    expect(
+      testConfig.get('object', defaultOtherTestObject, isOtherTestObject),
+    ).toStrictEqual(defaultOtherTestObject);
+  });
+
+  test('Test optional type guard default when given a narrower type', () => {
+    const narrowerOtherTestObject = {
+      someProp: 'specificallyThisString',
+      otherProp: 0,
+    } as const;
+    expect(
+      testConfig.get('object', narrowerOtherTestObject, isOtherTestObject),
+    ).toStrictEqual(narrowerOtherTestObject);
+  });
+
+  test('Test optional type guard default when given a wider type', () => {
+    const widerOtherTestObject = {
+      someProp: 'Wider type than OtherTestObject',
+    };
+    expect(
+      testConfig.get('object', widerOtherTestObject, isOtherTestObject),
+    ).toStrictEqual(widerOtherTestObject);
+  });
+
+  test('Test optional type guard default when given null', () => {
+    expect(testConfig.get('object', null, isOtherTestObject)).toBeNull();
+  });
+
+  test('Test optional type guard default given undefined', () => {
+    expect(
+      testConfig.get('object', undefined, isOtherTestObject),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
The behavior prior to this change was only type-safe for simple
primitive types. Complex objects or Arrays of objects would be
dangerously type-cast.

This change addresses the issue by accepting an optional type guard
function as a third parameter. If it is not supplied, the behavior
remains unchanged from prior releases. If it is supplied, the property
access is checked against the type guard prior to returning. If the type
guard resolves to false, then the default value is returned instead.

In cases where a null or undefined default value is passed and type
guard is supplied for a non-nullable type in strict mode, the type
should resolve to `T | null` or `T | undefined`. Similarly, wider types
in the default will resolve to the wider type for the end value.
Narrower types will remain as the wider type `T`.

This allows for type-safe access of dynamic values (assuming the
type guard function is well-written).

---

Here's a minimal playground example showcasing the way the types work for this:

```typescript
const get = <T, > (
  key: string, 
  defaultValue: T, 
  typeGuard?: (val: unknown) => val is T
): T => {
  const dynamic = JSON.parse(key.length > 1 ? '{"category": "real"}' : '{"other": 10}')
  if (typeGuard) {
    return typeGuard(dynamic) ? dynamic : defaultValue
  }
  return defaultValue
}

interface Thing {
  category: 'real' | 'imaginary'
}
const defaultThing: Thing = { category: 'real' }

const isThing = (obj: any): obj is Thing => {
  return obj?.category === 'real' || obj?.category === 'imaginary'
}

const regularExample = get('key', defaultThing, isThing)
// Type of regularExample is Thing

const nullableExample = get('key', null, isThing)
// Type of nullableExample is Thing | null

const undefinedAbleExample = get('key', undefined, isThing)
// Type of undefinedAbleExample is Thing | undefined

interface NarrowerThing extends Thing {
  category: 'real'
}
const narrowerTypedDefaultThing: NarrowerThing = { category: 'real' }
const narrowerDefaultTypeExample = get('key', narrowerTypedDefaultThing, isThing)
// Type of narrowerDefaultTypeExample is Thing

interface WiderThing {
  category: Thing['category'] | 'transcendent'
}
const widerTypedDefaultThing: WiderThing = { category: 'transcendent' }
const widerDefaultTypeExample = get('key', widerTypedDefaultThing, isThing)
// Type of widerDefaultTypeExample is WiderThing

const otherTypedExample = get('key', { other: 'somethingElse' }, isThing)
// Type Error!
// Argument of type '{ other: string; }' is not assignable to parameter of type 'Thing'.
// Object literal may only specify known properties, and 'other' does not exist in type 'Thing'.
```

You can examine this example closer in the TypeScript playground [at this link](https://www.typescriptlang.org/play?ts=4.5.2#code/MYewdgzgLgBA5gU1gXhgHgCoBoYD4YAUAUDKTANYICeAXDNAE4CWYcOJZAJggGYCGAVwA2UAGp8hAhHWwwOpKFQAOCAOIC+DTgH46BAG4S6AsOTAgA7mACUMZPkNCYTCDAxFrMu-gDe8mKCQsJxUYHwAtkzAdjAAUgDKAPIAcgB0SpoQCASUVKlCCKxQABZ4MACMMNowAOQ+AETAfFAIcCAMVPV09QwIEvUAvjUwdHX1ICUIDF0VAAxD1v5MPISKKuqanLZ+ZLswvVACDGAwa2oaWgQhYZHAttXXEVEjMNz8wmISUv4D-gdHJzeghE4kkCCIvyILBaDH4wAQbmKLDgMB2ZCaLTaHVGvQkwwAPrUmOE+HAWJoqDUIURAtBXrxgVAMEjWDIWSjUD4As1Wu1aLVcUJhpDabAXMzkTECCAAEYAKzofDAVE8MFlcucrglrG8qL+SABavl2lSGN5HTsyFQNUFBMJ6pNZqxVEt1uJpPJHSpIvAdN6cGEmgAogAPCJKAoxRBQAg1XI1HBAj7atialOLAD0GbcygRIBW-sDDFD4cjLkRyKINN9sDAwiEfBlBRL4QjCNQ0dj8ZwdaEQhw4vZmezGFzapWvYbTYQLbbmorOsJk6ropgJjeLAQnAAgtPZ5GO0gu9QE2uwBuwFuBxB00QszmVOOzxet7vm2HW2WteyYIT17xN04KtoSmOEEWSTQGEsKYUxgBAQxac9v0lNFSCdPkcT6IVqVXMIGCgiwYNzTgABEGWTdk6Ag-DoIYWDOW5TEMIFLDhWrIIYDwgipjI94RFHFR93beAjzjE8e0g2iBK3XjGRTa9b3vaSny42jZOTXMhPnFNgLAGEwJgAB1JhuDon9UMY81+RTABtGp0K9ABdX9aigBglQgeFz0KKBvXYukLBMoiVFI8j+MooygrMyUGIc-kajcjyvO4PS2NXQLTPU-jNI-OdDxjMTKRwDLgpksKmXZBShzvEcx3zGASoYLKmRy0sEXLYzTJ0-zYAmYpSs4LT8uPIrUTVSYGFGCAQHCJB2SDIQsmFKrkWHB8ESDGiGAAQhqmBtwYANZr0p8zlqLk+qmOhGGRABuGAhnncxYD4CAICYOAwmnU4QBgDJ3NmmFTrHGoUxqVI9sSeUEGAWAhCYGEJBgEkXXAIQXQgFRgGWF0zEsE4lCglQGCgJgEAgHAlU4WpLoYYZOBAcnOImOCQxcMUTjO0H2XBoA).