### PR TITLE
Patch local storage exception

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "statsig-js",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "statsig-js",
-      "version": "4.10.0",
+      "version": "4.10.1",
       "license": "ISC",
       "dependencies": {
         "js-sha256": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsig-js",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "description": "Statsig JavaScript client SDK for single user environments.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/StatsigLocalStorage.ts
+++ b/src/utils/StatsigLocalStorage.ts
@@ -20,7 +20,9 @@ export default class StatsigLocalStorage {
       window != null &&
       window.localStorage != null
     ) {
-      return window.localStorage.setItem(key, value);
+      try {
+        window.localStorage.setItem(key, value);
+      } catch (e) {}
     } else {
       this.fallbackSessionCache[key] = value;
     }
@@ -33,7 +35,7 @@ export default class StatsigLocalStorage {
       window != null &&
       window.localStorage != null
     ) {
-      return window.localStorage.removeItem(key);
+      window.localStorage.removeItem(key);
     } else {
       delete this.fallbackSessionCache[key];
     }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Storage/setItem#exceptions

setItem() may throw an exception if the storage is full. Particularly, in Mobile Safari (since iOS 5) it always throws when the user enters private mode. (Safari sets the quota to 0 bytes in private mode, unlike other browsers, which allow storage in private mode using separate data containers.) Hence developers should make sure to always catch possible exceptions from setItem().
