### PR TITLE
support any environment name

### DIFF
--- a/src/StatsigSDKOptions.ts
+++ b/src/StatsigSDKOptions.ts
@@ -2,7 +2,7 @@ const DEFAULT_FEATURE_GATE_API = 'https://featuregates.org/v1/';
 const DEFAULT_EVENT_LOGGING_API = 'https://events.statsigapi.net/v1/';
 
 export type StatsigEnvironment = {
-  tier?: 'production' | 'staging' | 'development';
+  tier?: string;
   [key: string]: string | undefined;
 };
 


### PR DESCRIPTION
The environment tier type currently restricts environment names to be
either: 'production' | 'staging' | 'development', which may not map up
with what environemnets are named

This change allows environments with any names