### PR TITLE
Update type export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export { StatsigEnvironment, StatsigOptions } from './StatsigSDKOptions';
 export type {
   InitCompletionCallback,
   UpdateUserCompletionCallback,
+  GateEvaluationCallback,
 } from './StatsigSDKOptions';
 export { EvaluationReason } from './utils/EvaluationReason';
 export type { EvaluationDetails } from './StatsigStore';


### PR DESCRIPTION
# What

I modified the export statement in `index.ts` to export the `GateEvaluationCallback` type.

# Why

I am now implementing an application using React and using Datadog RUM to track user behavior. And I am trying to start to use the Feature Flag feature provided by Datadog with Statsig. [The Datadog official documentation](https://docs.datadoghq.com/real_user_monitoring/guide/setup-feature-flag-data-collection/?tab=browser#statsig-integration) suggests using gateEvaluationCallback from Statsig. I followed the instructions, but when I checked the options in the react-sdk, I couldn't find `gateEvaluationCallback` in `StatsigOptions` type, and thus, I faced difficulties in implementing it correctly.

<img width="400" alt="image" src="https://github.com/statsig-io/js-client/assets/32538736/aaf74798-aaf0-4bf3-acd5-ee52d61a6b2e">

https://github.com/statsig-io/react-sdk/blob/925d376939a4ac10ba56fd737201c19eefc7e3ad/src/StatsigOptions.ts#L10-L31

Therefore, I considered creating a pull request in the react-sdk to incorporate gateEvaluationCallback into the options type. However, since the GateEvaluationCallback type is not exported from the js-client, I am initiating this pull request. 

Once this pull request is merged, my plan is to create another modified pull request for the react-sdk.