### PR TITLE
Pointing the package link to npmjs vs. github

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > [!IMPORTANT]
 > This version of the SDK is now in maintainance mode and will only receive bug fixes.
-> All new features will be added to the [@statsig/js-client package](https://github.com/statsig-io/js-client-monorepo).
+> All new features will be added to the [@statsig/js-client package](https://www.npmjs.com/package/@statsig/js-client).
 > Users of the `statsig-js` npm package should migrate to the `@statsig/js-client` package by 1/31/2025.  See [this migration guide](https://docs.statsig.com/client/javascript-sdk/migrating-from-statsig-js?ref=gh_js).
 
 The JavaScript SDK for single user client environments. If you need a SDK for another language or server environment, check out our [other SDKs](https://docs.statsig.com/#sdks?ref=gh_js).


### PR DESCRIPTION
Because that's where people are seeing this banner.